### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include pma/plcs.json
+include *.txt


### PR DESCRIPTION
Include missing files in sdist for #2

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.5XNrzuMk2h
+ trap 'rm -rf /tmp/tmp.5XNrzuMk2h' EXIT
+ python -m venv /tmp/tmp.5XNrzuMk2h
+ python setup.py sdist -d /tmp/tmp.5XNrzuMk2h
running sdist
running egg_info
writing PMA.egg-info/PKG-INFO
writing dependency_links to PMA.egg-info/dependency_links.txt
writing entry points to PMA.egg-info/entry_points.txt
writing requirements to PMA.egg-info/requires.txt
writing top-level names to PMA.egg-info/top_level.txt
reading manifest file 'PMA.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'PMA.egg-info/SOURCES.txt'
running check
warning: Check: missing meta-data: if 'author' supplied, 'author_email' must be supplied too

creating PMA-1.0.4
creating PMA-1.0.4/PMA.egg-info
creating PMA-1.0.4/pma
copying files to PMA-1.0.4...
copying MANIFEST.in -> PMA-1.0.4
copying README.md -> PMA-1.0.4
copying requirements.txt -> PMA-1.0.4
copying setup.py -> PMA-1.0.4
copying PMA.egg-info/PKG-INFO -> PMA-1.0.4/PMA.egg-info
copying PMA.egg-info/SOURCES.txt -> PMA-1.0.4/PMA.egg-info
copying PMA.egg-info/dependency_links.txt -> PMA-1.0.4/PMA.egg-info
copying PMA.egg-info/entry_points.txt -> PMA-1.0.4/PMA.egg-info
copying PMA.egg-info/requires.txt -> PMA-1.0.4/PMA.egg-info
copying PMA.egg-info/top_level.txt -> PMA-1.0.4/PMA.egg-info
copying pma/__init__.py -> PMA-1.0.4/pma
copying pma/__main__.py -> PMA-1.0.4/pma
copying pma/classes.py -> PMA-1.0.4/pma
copying pma/cli.py -> PMA-1.0.4/pma
copying pma/exceptions.py -> PMA-1.0.4/pma
copying pma/plcs.json -> PMA-1.0.4/pma
Writing PMA-1.0.4/setup.cfg
Creating tar archive
removing 'PMA-1.0.4' (and everything under it)
+ cd /
+ /tmp/tmp.5XNrzuMk2h/bin/pip install /tmp/tmp.5XNrzuMk2h/PMA-1.0.4.tar.gz
Processing /tmp/tmp.5XNrzuMk2h/PMA-1.0.4.tar.gz
Collecting requests (from PMA==1.0.4)
  Using cached https://files.pythonhosted.org/packages/1a/70/1935c770cb3be6e3a8b78ced23d7e0f3b187f5cbfab4749523ed65d7c9b1/requests-2.23.0-py2.py3-none-any.whl
Collecting click (from PMA==1.0.4)
  Using cached https://files.pythonhosted.org/packages/d2/3d/fa76db83bf75c4f8d338c2fd15c8d33fdd7ad23a9b5e57eb6c5de26b430e/click-7.1.2-py2.py3-none-any.whl
Collecting idna<3,>=2.5 (from requests->PMA==1.0.4)
  Using cached https://files.pythonhosted.org/packages/89/e3/afebe61c546d18fb1709a61bee788254b40e736cff7271c7de5de2dc4128/idna-2.9-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests->PMA==1.0.4)
  Using cached https://files.pythonhosted.org/packages/57/2b/26e37a4b034800c960a00c4e1b3d9ca5d7014e983e6e729e33ea2f36426c/certifi-2020.4.5.1-py2.py3-none-any.whl
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests->PMA==1.0.4)
  Using cached https://files.pythonhosted.org/packages/e1/e5/df302e8017440f111c11cc41a6b432838672f5a70aa29227bf58149dc72f/urllib3-1.25.9-py2.py3-none-any.whl
Collecting chardet<4,>=3.0.2 (from requests->PMA==1.0.4)
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Installing collected packages: idna, certifi, urllib3, chardet, requests, click, PMA
  Running setup.py install for PMA: started
    Running setup.py install for PMA: finished with status 'done'
Successfully installed PMA-1.0.4 certifi-2020.4.5.1 chardet-3.0.4 click-7.1.2 idna-2.9 requests-2.23.0 urllib3-1.25.9
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.5XNrzuMk2h
```
